### PR TITLE
Prevent memory issues with large list

### DIFF
--- a/controllers/clusters/config_list.yaml
+++ b/controllers/clusters/config_list.yaml
@@ -6,6 +6,7 @@ noRecordsMessage: 'backend::lang.list.no_records'
 showSetup: true
 showCheckboxes: true
 filter: config_filter.yaml
+recordsPerPage: 20
 toolbar:
     buttons: list_toolbar
     search:


### PR DESCRIPTION
Since I imported a lot of clusters my backend struggled with cluster view.
It may become a problem for anyone at some point, the recordsPerPage property allow pagination 😄 